### PR TITLE
Han 161: Pantalla Home - Sin plantas

### DIFF
--- a/hanagotchi-app/src/components/home/Hanagotchi.tsx
+++ b/hanagotchi-app/src/components/home/Hanagotchi.tsx
@@ -1,35 +1,11 @@
 import { Image, ImageBackground, TouchableWithoutFeedback } from "react-native"
 import { Emotion } from "../../models/Hanagotchi"
-import depressed from "../../assets/hanagotchis/depressed.png";
-import happy from "../../assets/hanagotchis/happy.png";
-import overwhelmed from "../../assets/hanagotchis/overwhelmed.png";
-import relaxed from "../../assets/hanagotchis/relaxed.png";
-import sad from "../../assets/hanagotchis/sad.png";
-import uncomfortable from "../../assets/hanagotchis/uncomfortable.png";
-import annoyed from "../../assets/hanagotchis/annoyed.png";
-import drowned from "../../assets/hanagotchis/drowned.png";
-import sleepy from "../../assets/hanagotchis/sleepy.png";
-import laughing from "../../assets/hanagotchis/laughing.png";
-import backgroundBlob from "../../assets/hanagotchis/background_1.png";
 import { useImperativeHandle, forwardRef } from "react";
 import { Deviation } from "../../models/Measurement";
 import useHanagotchi from "../../hooks/useHanagotchi";
 import UserFeedbackDialog from "./UserFeedbackDialog";
 import { Plant } from "../../models/Plant";
-
-const sources = {
-    depressed: depressed, 
-    annoyed: annoyed,
-    drowned: drowned,
-    displeased: annoyed,
-    happy: happy, 
-    overwhelmed: overwhelmed, 
-    relaxed: relaxed, 
-    sad: sad, 
-    uncomfortable: uncomfortable,
-    laughing: laughing,
-    sleepy: sleepy,
-}
+import { sources } from "./imageSources";
 
 export type HanagotchiRef = {
     handleMeasurement: (deviations?: Deviation) => void;

--- a/hanagotchi-app/src/components/home/imageSources.ts
+++ b/hanagotchi-app/src/components/home/imageSources.ts
@@ -1,0 +1,24 @@
+import depressed from "../../assets/hanagotchis/depressed.png";
+import happy from "../../assets/hanagotchis/happy.png";
+import overwhelmed from "../../assets/hanagotchis/overwhelmed.png";
+import relaxed from "../../assets/hanagotchis/relaxed.png";
+import sad from "../../assets/hanagotchis/sad.png";
+import uncomfortable from "../../assets/hanagotchis/uncomfortable.png";
+import annoyed from "../../assets/hanagotchis/annoyed.png";
+import drowned from "../../assets/hanagotchis/drowned.png";
+import sleepy from "../../assets/hanagotchis/sleepy.png";
+import laughing from "../../assets/hanagotchis/laughing.png";
+
+export const sources = {
+    depressed: depressed, 
+    annoyed: annoyed,
+    drowned: drowned,
+    displeased: annoyed,
+    happy: happy, 
+    overwhelmed: overwhelmed, 
+    relaxed: relaxed, 
+    sad: sad, 
+    uncomfortable: uncomfortable,
+    laughing: laughing,
+    sleepy: sleepy,
+}

--- a/hanagotchi-app/src/screens/CompleteLoginScreen.tsx
+++ b/hanagotchi-app/src/screens/CompleteLoginScreen.tsx
@@ -69,6 +69,7 @@ const CompleteLoginScreen: React.FC<CompleteLoginProps> = ({ navigation, route }
             const filepath = profilePictureUrl(user.email, 'avatar');
             const userUpdated: User = {
                 ...user,
+                birthdate: new Date(user!.birthdate!.toISOString().split('T')[0]),
                 photo: user?.photo?.startsWith('file://') ? await uploadImage(user.photo ?? DEFAULT_PHOTO, filepath) : user.photo
             } as User;
             setUser(userUpdated);

--- a/hanagotchi-app/src/screens/HomeScreen.tsx
+++ b/hanagotchi-app/src/screens/HomeScreen.tsx
@@ -17,6 +17,7 @@ import HomeContent from '../components/home/HomeContent';
 import Carousel from 'react-native-snap-carousel';
 import { Plant } from '../models/Plant';
 import messaging from '@react-native-firebase/messaging';
+import NoPlantsHomeScreen from './NoPlantsHomeScreen';
 
 
 
@@ -71,9 +72,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
 
 
   if (plants.length == 0 && !isFetching) return (
-    <View style={{ margin: 100 }}>
-      <NoContent />
-    </View>
+      <NoPlantsHomeScreen />
   )
 
   if (isFetching) {

--- a/hanagotchi-app/src/screens/HomeScreen.tsx
+++ b/hanagotchi-app/src/screens/HomeScreen.tsx
@@ -86,20 +86,22 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   return (
       <SafeAreaView style={{ flex: 1, backgroundColor: BACKGROUND_COLOR }}>
         <View style={style.container}>
-          <IconButton icon={left} onPress={previousPlant} style={{
-            ...style.arrow,
-            position: 'absolute',
-            left: "3%",
-            top: "20%",
-            zIndex: 3,
-          }} />
-          <IconButton icon={right} onPress={nextPlant} style={{
+          {plants.length > 1 && <>
+            <IconButton icon={left} onPress={previousPlant} style={{
               ...style.arrow,
               position: 'absolute',
-              right: "3%",
+              left: "3%",
               top: "20%",
               zIndex: 3,
-          }} />
+            }} />
+            <IconButton icon={right} onPress={nextPlant} style={{
+                ...style.arrow,
+                position: 'absolute',
+                right: "3%",
+                top: "20%",
+                zIndex: 3,
+            }} />
+          </>}
           <Carousel
             loop
             scrollEnabled={false}

--- a/hanagotchi-app/src/screens/HomeScreen.tsx
+++ b/hanagotchi-app/src/screens/HomeScreen.tsx
@@ -72,7 +72,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
 
 
   if (plants.length == 0 && !isFetching) return (
-      <NoPlantsHomeScreen />
+      <NoPlantsHomeScreen redirectToAddPlantScreen={() => navigation.navigate("AddPlant")}/>
   )
 
   if (isFetching) {

--- a/hanagotchi-app/src/screens/NoPlantsHomeScreen.tsx
+++ b/hanagotchi-app/src/screens/NoPlantsHomeScreen.tsx
@@ -1,0 +1,48 @@
+import { SafeAreaView, StyleSheet, Image } from "react-native"
+import { BACKGROUND_COLOR, BEIGE, BEIGE_LIGHT, GREEN } from "../themes/globalThemes"
+import { sources } from "../components/home/imageSources"
+import {Text} from "react-native-paper"
+import LoaderButton from "../components/LoaderButton"
+
+const NoPlantsHomeScreen: React.FC = () => {
+    return <SafeAreaView style={style.container}>
+            <Text>¡Comienza agregando una planta!</Text>
+            <Image 
+                source={sources["relaxed"]}
+                style={{
+                    width: 250,
+                    height: 311,
+                    marginRight: 52,
+                    zIndex: 1
+                }}
+            />
+            <LoaderButton
+                buttonColor={GREEN}
+                textColor={BEIGE_LIGHT}
+                style={style.button}
+                labelStyle={{fontSize: 17}}
+            >
+                AÑADIR PLANTA
+            </LoaderButton>
+    </SafeAreaView>
+}
+
+const style = StyleSheet.create({
+    container: {
+      flex: 1,
+      paddingVertical: 100,
+      justifyContent: 'space-between',
+      alignItems: "center",
+      alignContent: "center",
+      borderWidth: 1,
+      backgroundColor: BACKGROUND_COLOR
+    },
+    button: {
+        borderRadius: 10,
+        width: "50%",
+        height: 50,
+        justifyContent: "center",
+    },
+});
+
+export default NoPlantsHomeScreen;

--- a/hanagotchi-app/src/screens/NoPlantsHomeScreen.tsx
+++ b/hanagotchi-app/src/screens/NoPlantsHomeScreen.tsx
@@ -35,7 +35,7 @@ const NoPlantsHomeScreen: React.FC<NoPlantsHomeScreenProps> = ({redirectToAddPla
                 buttonColor={GREEN}
                 textColor={BEIGE_LIGHT}
                 style={style.button}
-                labelStyle={{fontSize: 17}}
+                labelStyle={{fontSize: 15}}
                 onPress={redirectToAddPlantScreen}
             >
                 AÑADIR HANAGOTCHI

--- a/hanagotchi-app/src/screens/NoPlantsHomeScreen.tsx
+++ b/hanagotchi-app/src/screens/NoPlantsHomeScreen.tsx
@@ -1,19 +1,34 @@
-import { SafeAreaView, StyleSheet, Image } from "react-native"
+import { SafeAreaView, StyleSheet, Image, ImageBackground } from "react-native"
 import { BACKGROUND_COLOR, BEIGE, BEIGE_LIGHT, GREEN } from "../themes/globalThemes"
 import { sources } from "../components/home/imageSources"
 import {Text} from "react-native-paper"
 import LoaderButton from "../components/LoaderButton"
+import background from "../assets/hanagotchis/background_1.png"
 
-const NoPlantsHomeScreen: React.FC = () => {
-    return <SafeAreaView style={style.container}>
-            <Text>¡Comienza agregando una planta!</Text>
+type NoPlantsHomeScreenProps = {
+    redirectToAddPlantScreen:  () => void;
+}
+
+const NoPlantsHomeScreen: React.FC<NoPlantsHomeScreenProps> = ({redirectToAddPlantScreen}) => {
+    return (
+        <SafeAreaView style={style.container}>  
+            {/* <Image 
+                source={background}
+                style={{
+                    width: 350,
+                    height: 450,
+                    position: "absolute",
+                    top: "35%",
+                    left: "0%", 
+                }}
+            /> */}
+            <Text style={style.title}>¡Comienza agregando un Hanagotchi!</Text>
             <Image 
                 source={sources["relaxed"]}
                 style={{
                     width: 250,
                     height: 311,
                     marginRight: 52,
-                    zIndex: 1
                 }}
             />
             <LoaderButton
@@ -21,20 +36,21 @@ const NoPlantsHomeScreen: React.FC = () => {
                 textColor={BEIGE_LIGHT}
                 style={style.button}
                 labelStyle={{fontSize: 17}}
+                onPress={redirectToAddPlantScreen}
             >
-                AÑADIR PLANTA
+                AÑADIR HANAGOTCHI
             </LoaderButton>
-    </SafeAreaView>
+        </SafeAreaView>
+    );
 }
 
 const style = StyleSheet.create({
     container: {
       flex: 1,
-      paddingVertical: 100,
+      paddingVertical: 90,
       justifyContent: 'space-between',
       alignItems: "center",
       alignContent: "center",
-      borderWidth: 1,
       backgroundColor: BACKGROUND_COLOR
     },
     button: {
@@ -43,6 +59,13 @@ const style = StyleSheet.create({
         height: 50,
         justifyContent: "center",
     },
+    title: {
+        fontSize: 40,
+        fontFamily: "IBMPlexMono_Italic",
+        textAlign: 'center',
+        color: '#4F4C4F',
+        padding: 20,
+    }
 });
 
 export default NoPlantsHomeScreen;


### PR DESCRIPTION
## Linked ticket in Jira
- https://hanagotchi.atlassian.net/browse/HAN-161

## Describe your changes, marking the new features and possible risks
- Se agrega una pantalla en la Home para cuando un usuario no tiene plantas registradas.
- Es bastante simplona, por lo que cualquier idea para mejorar su diseño es bienvenida.
- El boton redirige a la pantalla de Agregar Planta.
- YAPA: Se arregla el problema del 422 en la pantalla de Completar Perfil. El backend no esta preparado para recibir dates de Typescript, por lo que se parseo el date para que coincida con el formato de los datetimes de Python.

## Media: upload photos or videos (if needed)
![image](https://github.com/Hanagotchi/app-mobile/assets/56854562/d5a7e1ad-d4f3-426b-8fb6-4e0b957d6347)

