### PR TITLE
Actualizacion del endpoint de obtencion de plantas

### DIFF
--- a/hanagotchi-app/src/components/EditUser.tsx
+++ b/hanagotchi-app/src/components/EditUser.tsx
@@ -13,10 +13,10 @@ import { User } from '../models/User';
 import { Text } from 'react-native-paper';
 
 type EditUserProps = {
-    user: User;
+    user: Partial<User>;
     name_button: string,
     onPressCompleteEdit: ((() => void) & Function);
-    setUser: React.Dispatch<React.SetStateAction<User | undefined>>;
+    setUser: React.Dispatch<React.SetStateAction<Partial<User> | undefined>>;
 }
 
 const EditUser: React.FC<EditUserProps> = ({ user, name_button, onPressCompleteEdit, setUser }) => {

--- a/hanagotchi-app/src/components/home/imageSources.ts
+++ b/hanagotchi-app/src/components/home/imageSources.ts
@@ -13,7 +13,7 @@ export const sources = {
     depressed: depressed, 
     annoyed: annoyed,
     drowned: drowned,
-    displeased: annoyed,
+    displeased: uncomfortable,
     happy: happy, 
     overwhelmed: overwhelmed, 
     relaxed: relaxed, 

--- a/hanagotchi-app/src/components/logs/EditLog.tsx
+++ b/hanagotchi-app/src/components/logs/EditLog.tsx
@@ -34,7 +34,7 @@ const EditLog: React.FC<EditLogProps> = ({initValues = defaultData, onSubmit, bu
     const [contentLen, setContentLen] = useState<number>(initValues.content.length);
     const id_user = useSession((state) => state.session?.userId)!;
     const api = useHanagotchiApi()
-    const {isFetching, fetchedData, error} = useApiFetch<GetPlantsResponse>(() => api.getPlants({id_user, limit: 1024}), []);
+    const {isFetching, fetchedData, error} = useApiFetch<GetPlantsResponse>(() => api.getPlants({limit: 1024}), []);
     const myPlants: SelectOption[] = useMemo(() => {
         return fetchedData.map(plant => ({
             key: plant.id,

--- a/hanagotchi-app/src/contexts/AuthContext.tsx
+++ b/hanagotchi-app/src/contexts/AuthContext.tsx
@@ -57,10 +57,8 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
             
             // Check if your device supports Google Play
             await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
-            console.log("ansdkjasndjksankdj")
 
             // Get the users ID token
-          
             const { idToken, serverAuthCode } = await GoogleSignin.signIn();
             
             
@@ -72,6 +70,7 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
                     "x-access-token": accessToken
                 }
             } : LoginResponse = await hanagotchiApi.logIn(serverAuthCode ?? "null");
+            console.log(user.id, accessToken);
             createSession(user.id, accessToken);
 
             // Create a Google credential with the token

--- a/hanagotchi-app/src/contexts/HanagotchiServiceContext.tsx
+++ b/hanagotchi-app/src/contexts/HanagotchiServiceContext.tsx
@@ -16,10 +16,10 @@ const api: HanagotchiApi = new HanagotchiApiImpl(axiosInstance);
 export const HanagotchiApiContext = createContext<HanagotchiApi | undefined>(api);
 
 export const HanagotchiApiProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const accessToken = useSession((state) => state.session?.accessToken);
-  console.log("access token", accessToken);
+  const getAccessToken = useSession((state) => state.getAccessToken);
 
-  const updateHeader = (request: InternalAxiosRequestConfig) => {
+  const updateHeader = async (request: InternalAxiosRequestConfig) => {
+    const accessToken = await getAccessToken();
     if (accessToken) {
       request.headers = {
         ...request.headers,

--- a/hanagotchi-app/src/contexts/HanagotchiServiceContext.tsx
+++ b/hanagotchi-app/src/contexts/HanagotchiServiceContext.tsx
@@ -17,6 +17,7 @@ export const HanagotchiApiContext = createContext<HanagotchiApi | undefined>(api
 
 export const HanagotchiApiProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const accessToken = useSession((state) => state.session?.accessToken);
+  console.log("access token", accessToken);
 
   const updateHeader = (request: InternalAxiosRequestConfig) => {
     if (accessToken) {

--- a/hanagotchi-app/src/hooks/useMyPlants.tsx
+++ b/hanagotchi-app/src/hooks/useMyPlants.tsx
@@ -10,7 +10,7 @@ export const useMyPlants = () => {
     const api = useHanagotchiApi();
 
     const {isFetching, fetchedData, error} = useFocusApiFetch<Plant[]>(
-        () => api.getPlants({id_user: userId}),
+        () => api.getPlants(),
         [],
     );
 

--- a/hanagotchi-app/src/hooks/usePlantInfo.tsx
+++ b/hanagotchi-app/src/hooks/usePlantInfo.tsx
@@ -23,7 +23,6 @@ export const usePlantInfo = (plant: Plant) => {
             setIsFetching(true);
             setDevice(undefined);
             const devicePlant = await hanagotchiApi.getDevicePlants({id_plant: plant.id});
-            console.log(devicePlant);
             if ((devicePlant as DevicePlant[]).length > 0) {
                 setDevice(devicePlant as DevicePlant)
                 const measurement = await hanagotchiApi.getLastMeasurement(plant.id);
@@ -38,9 +37,7 @@ export const usePlantInfo = (plant: Plant) => {
             } else {
                 try {
                     if (myUser?.location) {
-                        console.log("nasdjkasd")
                         const weatherData = await openWeatherApi.getCurrentWeather(myUser.location.lat!, myUser.location.long!)
-                        console.log(weatherData);
                         const timestamp = new Date(0);
                         timestamp.setUTCSeconds(weatherData.dt);
                         setPlantInfo({

--- a/hanagotchi-app/src/hooks/usePlantInfo.tsx
+++ b/hanagotchi-app/src/hooks/usePlantInfo.tsx
@@ -23,7 +23,8 @@ export const usePlantInfo = (plant: Plant) => {
             setIsFetching(true);
             setDevice(undefined);
             const devicePlant = await hanagotchiApi.getDevicePlants({id_plant: plant.id});
-            if ((devicePlant as DevicePlant[]).length > 0) {
+            console.log(devicePlant);
+            if (devicePlant) {
                 setDevice(devicePlant as DevicePlant)
                 const measurement = await hanagotchiApi.getLastMeasurement(plant.id);
                 if (!measurement) {

--- a/hanagotchi-app/src/hooks/usePlantInfo.tsx
+++ b/hanagotchi-app/src/hooks/usePlantInfo.tsx
@@ -23,7 +23,8 @@ export const usePlantInfo = (plant: Plant) => {
             setIsFetching(true);
             setDevice(undefined);
             const devicePlant = await hanagotchiApi.getDevicePlants({id_plant: plant.id});
-            if (devicePlant) {
+            console.log(devicePlant);
+            if ((devicePlant as DevicePlant[]).length > 0) {
                 setDevice(devicePlant as DevicePlant)
                 const measurement = await hanagotchiApi.getLastMeasurement(plant.id);
                 if (!measurement) {
@@ -37,7 +38,9 @@ export const usePlantInfo = (plant: Plant) => {
             } else {
                 try {
                     if (myUser?.location) {
+                        console.log("nasdjkasd")
                         const weatherData = await openWeatherApi.getCurrentWeather(myUser.location.lat!, myUser.location.long!)
+                        console.log(weatherData);
                         const timestamp = new Date(0);
                         timestamp.setUTCSeconds(weatherData.dt);
                         setPlantInfo({

--- a/hanagotchi-app/src/hooks/useSession.tsx
+++ b/hanagotchi-app/src/hooks/useSession.tsx
@@ -1,4 +1,4 @@
-import {create} from "zustand";
+import {create, UseBoundStore} from "zustand";
 import * as SecureStore from "expo-secure-store";
 
 type SessionData = {
@@ -11,9 +11,10 @@ type Session = {
     createSession: (newUserId: number, newAccessToken: string) => Promise<void>;
     deleteSession: () => Promise<void>;
     loadFromSecureStore: () => Promise<SessionData | null>;
+    getAccessToken: () => Promise<string | undefined>;
 }
 
-export const useSession = create<Session>()((set) => ({
+export const useSession = create<Session>()((set, get) => ({
     session: null,
     createSession: async (newUserId: number, newAccessToken: string) => {
         const newSession = {userId: newUserId, accessToken: newAccessToken};
@@ -33,4 +34,5 @@ export const useSession = create<Session>()((set) => ({
         set((_) => ({session: lastSession}));
         return lastSession;
     },
-}))
+    getAccessToken: async () => get().session?.accessToken,
+}));

--- a/hanagotchi-app/src/screens/AddSensorScreen.tsx
+++ b/hanagotchi-app/src/screens/AddSensorScreen.tsx
@@ -30,7 +30,7 @@ const AddSensorScreen: React.FC<AddSensorProps> = ({navigation}) => {
     const [isButtonEnabled, setIsButtonEnabled] = useState(false);
     const [errorMsg, setErrorMsg] = useState<string>("");
     const {isFetching: isFetchingPlant, fetchedData: plants} = useApiFetch(
-        () => api.getPlants({id_user: userId}),
+        () => api.getPlants(),
         [{
             id: 0,
             id_user: 0,

--- a/hanagotchi-app/src/screens/CompleteLoginScreen.tsx
+++ b/hanagotchi-app/src/screens/CompleteLoginScreen.tsx
@@ -23,7 +23,7 @@ const CompleteLoginScreen: React.FC<CompleteLoginProps> = ({ navigation, route }
     const { signOut, completeSignIn } = useAuth();
     const { requestLocation, revokeLocation } = useLocation();
     const { uploadImage } = useFirebase();
-    const [user, setUser] = useState<User>();
+    const [user, setUser] = useState<Partial<User>>();
     const { isFetching, fetchedData, error } = useApiFetch(
         () => api.getUser(userId),
         user
@@ -66,13 +66,15 @@ const CompleteLoginScreen: React.FC<CompleteLoginProps> = ({ navigation, route }
             return;
         }
         try {
-            const filepath = profilePictureUrl(user.email, 'avatar');
-            const userUpdated: User = {
+            const filepath = profilePictureUrl(user.email!, 'avatar');
+            const userUpdated: Partial<User> = {
                 ...user,
                 birthdate: new Date(user!.birthdate!.toISOString().split('T')[0]),
                 photo: user?.photo?.startsWith('file://') ? await uploadImage(user.photo ?? DEFAULT_PHOTO, filepath) : user.photo
             } as User;
+            delete userUpdated.nickname;
             setUser(userUpdated);
+            console.log(userUpdated)
             await api.patchUser(userUpdated);
             await completeSignIn();
             navigation.navigate("MainScreens", { screen: "Home", params: { bgColor: "blue" } });

--- a/hanagotchi-app/src/screens/DeletePlantScreen.tsx
+++ b/hanagotchi-app/src/screens/DeletePlantScreen.tsx
@@ -27,7 +27,7 @@ const DeletePlantScreen: React.FC<DeletePlantProps> = ({navigation}) => {
     const dialogRef = useRef<DialogRef>(null);
 
     const {isFetching, fetchedData: plants} = useApiFetch(
-        () => api.getPlants({id_user: userId}),
+        () => api.getPlants(),
         [{
             id: 0,
             id_user: 0,

--- a/hanagotchi-app/src/screens/DeleteSensorScreen.tsx
+++ b/hanagotchi-app/src/screens/DeleteSensorScreen.tsx
@@ -27,7 +27,7 @@ const DeleteSensorScreen: React.FC<DeleteSensorProps> = ({navigation}) => {
     const dialogRef = useRef<DialogRef>(null);
     const [errorMsg, setErrorMsg] = useState<string>("");
     const {isFetching: isFetchingPlants, fetchedData: plants} = useApiFetch(
-        () => api.getPlants({id_user: userId}),
+        () => api.getPlants(),
         [{
             id: 0,
             id_user: 0,

--- a/hanagotchi-app/src/screens/HomeScreen.tsx
+++ b/hanagotchi-app/src/screens/HomeScreen.tsx
@@ -32,7 +32,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const carouselRef = useRef<Carousel<Plant>>(null);
 
   const { isFetching, fetchedData: plants, error } = useFocusApiFetch(
-    () => api.getPlants({ id_user: userId }),
+    () => api.getPlants(),
     [{
       id: 0,
       id_user: 0,

--- a/hanagotchi-app/src/screens/LoginScreen.tsx
+++ b/hanagotchi-app/src/screens/LoginScreen.tsx
@@ -11,6 +11,7 @@ import { handleError } from "../common/errorHandling";
 import LoaderButton from "../components/LoaderButton";
 import { statusCodes } from "@react-native-google-signin/google-signin";
 import { User } from "../models/User";
+import { useSession } from "../hooks/useSession";
 
 type LoginScreenProps = CompositeScreenProps<
     NativeStackScreenProps<RootStackParamsList, "Login">,

--- a/hanagotchi-app/src/screens/SettingsScreen.tsx
+++ b/hanagotchi-app/src/screens/SettingsScreen.tsx
@@ -33,7 +33,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({navigation}) => {
 
     useEffect(() => {
         if (myPlants && myPlants.length > 0) {
-            const filteredPlants = myPlants.filter((plant) => devicePlants!.some((it) => it.id_plant === plant.id));
+            const filteredPlants = myPlants.filter((plant) => devicePlants.some((it) => it.id_plant === plant.id));
             setHasDevicePlants(filteredPlants.length > 0);
             setAllPlantsHaveSensor(myPlants.length === filteredPlants.length)
         }

--- a/hanagotchi-app/src/screens/logs/LogDetailsScreen.tsx
+++ b/hanagotchi-app/src/screens/logs/LogDetailsScreen.tsx
@@ -21,7 +21,7 @@ const LogDetailsScreen: React.FC<LogDetailsScreenProps> = ({route, navigation}) 
     const userId = useSession((state) => state.session?.userId);
     const api = useHanagotchiApi();
 
-    const {isFetching: isFetchingMyPlants, fetchedData: myPlants, error: plantsError} = useApiFetch(() => api.getPlants({id_user: userId}), []);
+    const {isFetching: isFetchingMyPlants, fetchedData: myPlants, error: plantsError} = useApiFetch(() => api.getPlants(), []);
 
     const {
         isFetching,

--- a/hanagotchi-app/src/services/hanagotchiApi.tsx
+++ b/hanagotchi-app/src/services/hanagotchiApi.tsx
@@ -53,7 +53,7 @@ export interface HanagotchiApi {
     getPostById: (postId: string) => Promise<Post>;
     createPost: (post: PostData) => Promise<Post>;
     deletePost: (postId: string) => Promise<void>;
-    getDevicePlants: (params?: {id_plant?: number, limit?: number}) => Promise<GetDevicePlantsResponse>
+    getDevicePlants: (params?: {id_plant?: number, limit?: number}) => Promise<GetDevicePlantsResponse | null>
     getMyFeed: (page: number, size: number) => Promise<ReducedPost[]>;
     likePost: (postId: string) => Promise<void>;
     unlikePost: (postId: string) => Promise<void>;
@@ -99,9 +99,14 @@ export class HanagotchiApiImpl implements HanagotchiApi {
         return GetPlantsResponseSchema.parse(data)
     }
 
-    async getDevicePlants(params?: {id_plant?: number, limit?: number}): Promise<GetDevicePlantsResponse> {
+    async getDevicePlants(params?: {id_plant?: number, limit?: number}): Promise<GetDevicePlantsResponse | null> {
         const { data, status } = await this.axiosInstance.get(`/measurements/device-plant`, {params});
-        if (status == 204) return []
+        if (status == 204) {
+            if (params?.id_plant) {
+                return null;
+            }
+            return []
+        }
         return GetDevicePlantsResponseSchema.parse(data);
     }
 

--- a/hanagotchi-app/src/services/hanagotchiApi.tsx
+++ b/hanagotchi-app/src/services/hanagotchiApi.tsx
@@ -45,7 +45,7 @@ export interface HanagotchiApi {
     deletePlant: (plantId: number) => Promise<void>;
     getLogsByUser: (userId: number, params: { year: number, month?: number }) => Promise<GetLogsByUserResponse>;
     getLogById: (logId: number) => Promise<GetLogByIdResponse>;
-    getPlants: (params: { id_user?: number, limit?: number }) => Promise<GetPlantsResponse>;
+    getPlants: (params?: { limit?: number }) => Promise<GetPlantsResponse>;
     createLog: (log: CreateLog) => Promise<Log>;
     editLog: (logId: number, updateSet: PartialUpdateLog) => Promise<Log>;
     addPhotoToLog: (logId: number, body: { photo_link: string }) => Promise<Log>;
@@ -94,7 +94,7 @@ export class HanagotchiApiImpl implements HanagotchiApi {
         await this.axiosInstance.delete(`/plants/${plantId}`)
     }
 
-    async getPlants(params: { id_user?: number, limit?: number }): Promise<GetPlantsResponse> {
+    async getPlants(params?: { limit?: number }): Promise<GetPlantsResponse> {
         const { data } = await this.axiosInstance.get(`/plants`, { params });
         return GetPlantsResponseSchema.parse(data)
     }

--- a/hanagotchi-app/src/services/hanagotchiApi.tsx
+++ b/hanagotchi-app/src/services/hanagotchiApi.tsx
@@ -39,7 +39,7 @@ export interface HanagotchiApi {
     getPlantType: (name: string) => Promise<GetPlantTypeResponse>;
     getUser: (userId: number) => Promise<User>;
     getLastMeasurement: (plantId: number) => Promise<Measurement | null>;
-    patchUser: (user: UpdateUser) => Promise<void>;
+    patchUser: (user: Partial<UpdateUser>) => Promise<void>;
     getPlantTypes: () => Promise<GetPlantTypesResponse>;
     createPlant: (id_user: number, name: string, scientific_name: string) => Promise<Plant>;
     deletePlant: (plantId: number) => Promise<void>;

--- a/hanagotchi-app/src/services/hanagotchiApi.tsx
+++ b/hanagotchi-app/src/services/hanagotchiApi.tsx
@@ -53,7 +53,7 @@ export interface HanagotchiApi {
     getPostById: (postId: string) => Promise<Post>;
     createPost: (post: PostData) => Promise<Post>;
     deletePost: (postId: string) => Promise<void>;
-    getDevicePlants: (params?: {id_plant?: number, limit?: number}) => Promise<GetDevicePlantsResponse | null>
+    getDevicePlants: (params?: {id_plant?: number, limit?: number}) => Promise<GetDevicePlantsResponse>
     getMyFeed: (page: number, size: number) => Promise<ReducedPost[]>;
     likePost: (postId: string) => Promise<void>;
     unlikePost: (postId: string) => Promise<void>;
@@ -99,9 +99,9 @@ export class HanagotchiApiImpl implements HanagotchiApi {
         return GetPlantsResponseSchema.parse(data)
     }
 
-    async getDevicePlants(params?: {id_plant?: number, limit?: number}): Promise<GetDevicePlantsResponse | null> {
+    async getDevicePlants(params?: {id_plant?: number, limit?: number}): Promise<GetDevicePlantsResponse> {
         const { data, status } = await this.axiosInstance.get(`/measurements/device-plant`, {params});
-        if (status == 204) return null
+        if (status == 204) return []
         return GetDevicePlantsResponseSchema.parse(data);
     }
 


### PR DESCRIPTION
## Describe your changes, marking the new features and possible risks
- Debido a los cambios introducidos en https://github.com/Hanagotchi/plants/pull/20, se actualizo el endpoint de **get_plants** para ya no recibir el user_id por parametro de url, sino inferirlo por el access_token brindado.
- En base a esto, se removio el pase de user_id en todas las llamadas a dicho endpoint.

Por algun motivo que desconozco, Github esta incluyendo commits de un PR anterior que ya esta mergeado. Vayan a la pestaña de commits y hagan review solo del ultimo commit.